### PR TITLE
Fix typos in guinness.py

### DIFF
--- a/guinness.py
+++ b/guinness.py
@@ -778,7 +778,7 @@ class Layout(QtGui.QWidget):
                         idx = 0
                     elif val == 'zybo':
                         idx = 1
-                    elif val == 'vc702':
+                    elif val == 'zc702':
                         idx = 2
                     else: # zcu102
                         idx = 3

--- a/guinness.py
+++ b/guinness.py
@@ -89,7 +89,7 @@ class Layout(QtGui.QWidget):
         vbox_left_column.addWidget(project_setup_box)
 
         # cnn setup table ------------------------------------------------
-        cnn_setup_box = QtGui.QGroupBox("2. CNN Specificaion")
+        cnn_setup_box = QtGui.QGroupBox("2. CNN Specification")
 
         vbox_cnn = QtGui.QVBoxLayout()
 
@@ -163,7 +163,7 @@ class Layout(QtGui.QWidget):
         vbox_training.addLayout(hbox_tl)
 
         # # of training
-        n_trains = QtGui.QLabel('Number of traning')
+        n_trains = QtGui.QLabel('Number of Training')
         self.n_trains_Edit = QtGui.QLineEdit()
         self.n_trains_Edit.setText("10")
 


### PR DESCRIPTION
Thank you for sharing a great project.
This pull request contains the following fixes:
These fixes have been tested.
These do not affect training results or C/C++ code generation results.

* Fix typos in GUI
* Fix the typo related to the typo reported in HirokiNakahara/GUINNESS#8
* The problem that the project using ZC702 as a target FPGA board can not be read normally is solved